### PR TITLE
Fix clippy un-inlined format args

### DIFF
--- a/src/clients/gemini.rs
+++ b/src/clients/gemini.rs
@@ -90,8 +90,9 @@ impl AiClient for Gemini {
         };
 
         let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-            self.model, self.key
+            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}",
+            model = self.model,
+            key = self.key
         );
 
         execute_with_retry(self.retries, || async {

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,11 +20,11 @@ pub enum ClientError {
 impl fmt::Display for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ClientError::Network(msg) => write!(f, "Network error: {}", msg),
-            ClientError::Api(msg) => write!(f, "API error: {}", msg),
-            ClientError::Authentication(msg) => write!(f, "Authentication error: {}", msg),
-            ClientError::Configuration(msg) => write!(f, "Configuration error: {}", msg),
-            ClientError::Parse(msg) => write!(f, "Parse error: {}", msg),
+            ClientError::Network(msg) => write!(f, "Network error: {msg}"),
+            ClientError::Api(msg) => write!(f, "API error: {msg}"),
+            ClientError::Authentication(msg) => write!(f, "Authentication error: {msg}"),
+            ClientError::Configuration(msg) => write!(f, "Configuration error: {msg}"),
+            ClientError::Parse(msg) => write!(f, "Parse error: {msg}"),
         }
     }
 }
@@ -44,7 +44,7 @@ impl From<reqwest::Error> for ClientError {
             } else if status.as_u16() == 429 {
                 ClientError::Api("Rate limit exceeded".to_string())
             } else {
-                ClientError::Api(format!("HTTP {}: {}", status, err))
+                ClientError::Api(format!("HTTP {status}: {err}"))
             }
         } else {
             ClientError::Network(err.to_string())
@@ -54,6 +54,6 @@ impl From<reqwest::Error> for ClientError {
 
 impl From<serde_json::Error> for ClientError {
     fn from(err: serde_json::Error) -> Self {
-        ClientError::Parse(format!("JSON parsing failed: {}", err))
+        ClientError::Parse(format!("JSON parsing failed: {err}"))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub fn create_client(
     let http_client = Client::builder()
         .timeout(config.timeout)
         .build()
-        .map_err(|e| ClientError::Configuration(format!("Failed to create HTTP client: {}", e)))?;
+        .map_err(|e| ClientError::Configuration(format!("Failed to create HTTP client: {e}")))?;
 
     match provider.to_lowercase().as_str() {
         "openai" | "gpt" | "chatgpt" => Ok(Box::new(ChatGpt::new(
@@ -125,8 +125,7 @@ pub fn create_client(
             config,
         ))),
         _ => Err(ClientError::Configuration(format!(
-            "Unknown provider: {}. Supported providers: openai, google, anthropic",
-            provider
+            "Unknown provider: {provider}. Supported providers: openai, google, anthropic",
         ))),
     }
 }
@@ -225,7 +224,7 @@ pub async fn generate_summary(
 ) -> Result<String, ClientError> {
     let mut summary_prompt = "Given these AI model responses:\n".to_string();
     for (name, response) in responses {
-        summary_prompt.push_str(&format!("{}:\n{}\n---\n", name, response));
+        summary_prompt.push_str(&format!("{name}:\n{response}\n---\n"));
     }
     summary_prompt.push_str("Summarize the key differences and commonalities.");
 


### PR DESCRIPTION
## Summary
- update `write!` and `format!` calls to use named arguments
- update gemini client URL formatting
- update summary generation formatting

## Testing
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6874765493c4832599dde411825a249c